### PR TITLE
Fix for KSA 2026.3.8.3883

### DIFF
--- a/Sources/KSA.XR/XrViewports.cs
+++ b/Sources/KSA.XR/XrViewports.cs
@@ -313,7 +313,7 @@ namespace KSA.XR
 			if (frameResources == null || frameResources.Length == 0)
 				return;
 
-			int frameIndex = __instance.FrameIndex;
+			int frameIndex = __instance.SwapchainImageIndex;
 			if (frameIndex < 0 || frameIndex >= frameResources.Length)
 				return;
 


### PR DESCRIPTION
`FrameIndex` was renamed to `SwapchainImageIndex` in `Planet.Render.Core.dll`

Using 2026.3.8.3883 also fixes game crash when XR is active and user press F2 (hide UI).